### PR TITLE
Migrate to Node.js 4.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,13 +1,17 @@
 {
     "name":     "w3c-spec-generator"
-,   "version":  "0.0.1"
+,   "version":  "0.0.2"
 ,   "private":  true
 ,   "license": "MIT"
 ,   "dependencies": {
         "respec":       "3.2.28"
-    ,   "phantomjs":    "1.9.12"
+    ,   "phantomjs":    "1.9.18"
     ,   "express":      "4.10.2"
     ,   "request":      "~2.51.0"
     ,   "whacko":       "^0.18.1"
+    },
+    "engines": {
+        "node": ">=4.1.2",
+        "npm": ">=3.3.6"
     }
 }


### PR DESCRIPTION
* Node.js &ge; `4.1.2`, npm &ge; `3.3.6` ([advisory only](https://docs.npmjs.com/files/package.json#engines))
* phantomjs threw an error in its current version with latest Node.js; version updated
* Patch no. increased to reflect this

Fixes #17.

@deniak: please merge this in sync with w3c/echidna#236 and w3c/specberus#263, to be able to [update Node.js and npm in production](https://github.com/nodesource/distributions#manual-installation) right after.