### PR TITLE
Disallow https://www.w3.org/scripts/. Fixes #21

### DIFF
--- a/generators/respec.js
+++ b/generators/respec.js
@@ -26,7 +26,7 @@ exports.generate = function (url, params, cb) {
     );
     var childProcess = spawn(
         phantom.path
-    ,   ["--ssl-protocol=any", r2hPath, url]
+    ,   ["--ssl-protocol=any", r2hPath, "--exclude-script", "https://www.w3.org/scripts/", url]
     ,   { detached: true }
     );
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "express":      "^4.13.3"
     ,   "phantomjs":    "^1.9.19"
     ,   "request":      "^2.67.0"
-    ,   "respec":       "^3.2.90"
+    ,   "respec":       "^3.2.92"
     ,   "whacko":       "^0.18.1"
     },
     "engines": {


### PR DESCRIPTION
npm needs to get its respec upgraded before we can deploy this.
