### PR TITLE
fix undefined error variable

### DIFF
--- a/generators/respec.js
+++ b/generators/respec.js
@@ -16,6 +16,6 @@ exports.generate = function (url, params, cb) {
     respecWriter(url, '/dev/null', {}, 20000).then(function(html) {
         cb(null, html);
     }).catch(function (err) {
-        cb({ status: 500, message: err + "\n" + error });
+        cb({ status: 500, message: err.message });
     });
 };


### PR DESCRIPTION
`generators/respec.js` produces an `UnhandledPromiseRejectionWarning` because `error` is not defined:
`(node:21396) UnhandledPromiseRejectionWarning: Unhandled promise rejection (rejection id: 1): ReferenceError: error is not defined`

It should use `err.message` instead.