### PR TITLE
upgrade to respec 6

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
 ,   "dependencies": {
         "express":      "^4.13.3"
     ,   "request":      "^2.67.0"
-    ,   "respec":       "^4.3.0"
+    ,   "respec":       "^6.1.5"
     ,   "whacko":       "^0.18.1"
     },
     "engines": {


### PR DESCRIPTION
The latest release of respec fixes a [bug](https://github.com/w3c/respec/pull/977) on electron processes not correctly closed.