### PR TITLE
Add a simple test suite (and fix a couple other things)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,3 +11,4 @@ script:
   - npx respec2html -e --timeout 30 --src https://w3c.github.io/manifest/?$AUTHORIZATION --out /dev/null
   - npx respec2html -e --timeout 30 --src https://w3c.github.io/payment-request/?$AUTHORIZATION --out /dev/null
   - npx respec2html -e --timeout 30 --src https://w3c.github.io/resource-hints/?$AUTHORIZATION --out /dev/null
+  - npm test

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,3 +12,11 @@ script:
   - npx respec2html -e --timeout 30 --src https://w3c.github.io/payment-request/?$AUTHORIZATION --out /dev/null
   - npx respec2html -e --timeout 30 --src https://w3c.github.io/resource-hints/?$AUTHORIZATION --out /dev/null
   - npm test
+notifications:
+  email: false
+  irc:
+    channels:
+      - "irc.w3.org#pub"
+    skip_join: true
+    template:
+      - "%{branch} by %{author} (%{build_url}): %{message}"

--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ This exposes a service to automatically generate specs from various source forma
 
 ## API
 
+### Via HTTP
+
+Start the server listening on port 80 by default:
+
+```bash
+node server
+```
+
+You can specify a port like so:
+
+```bash
+PORT=3000 node server
+```
+
 Spec Generator has a single endpoint, which is a `GET /`. This endpoint accepts parameters on its
 query string. If the call is successful the generated content of the specification is returned.
 
@@ -13,6 +27,15 @@ query string. If the call is successful the generated content of the specificati
   `respec`.
 * `url` (required). The URL of the draft to fetch and generate from.
 * `publishDate`. The date at which the publication of this draft is supposed to occur.
+
+### As a Node.js module
+
+```js
+const SPEC_GEN = require('w3c-spec-generator');
+const SERVER = SPEC_GEN.start();    // Optional port number (80 by default)
+// Now Spec Generator is listening on port 80
+SERVER.close();    // To stop the server
+```
 
 ### Errors
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://travis-ci.org/w3c/spec-generator.svg?branch=master)](https://travis-ci.org/w3c/spec-generator)
 [![Greenkeeper badge](https://badges.greenkeeper.io/w3c/spec-generator.svg)](https://greenkeeper.io/)
 
 # Spec Generator

--- a/package.json
+++ b/package.json
@@ -9,8 +9,14 @@
     "respec": "20.10.1",
     "whacko": "0.19.1"
   },
+  "devdependencies": {
+    "mocha": "5.1.0"
+  },
   "engines": {
     "node": ">=5.10",
     "npm": ">=3.3.6"
+  },
+  "scripts": {
+    "test": "mocha"
   }
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "respec": "20.10.1",
     "whacko": "0.19.1"
   },
-  "devdependencies": {
+  "devDependencies": {
     "mocha": "5.1.0"
   },
   "engines": {

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,4 @@
+--colors
+--growl
+--reporter spec
+--timeout 30000

--- a/test/test.js
+++ b/test/test.js
@@ -5,15 +5,15 @@ const ASSERT = require('assert'),
   SPEC_GEN = require('../server');
 
 const PORT = 3000,
-  BASE_URL = 'http://localhost:3000/',
-  NO_URL = '?type=foo&URL=notice-that-its-in-uppercase',
-  NO_TYPE = '?url=foo&TYPE=notice-that-its-in-uppercase',
-  BAD_GENERATOR = '?type=fluxor&url=http://example.com/',
-  BAD_SHORTNAME = '?type=RESPEC&url=http://example.com/%3FshortName%3Ddiplodocus',
-  NO_RESPEC = '?type=RESPEC&url=http://example.com/',
-  SUCCESS1 = '?type=respec&url=https://w3c.github.io/manifest/',
-  SUCCESS2 = '?type=respec&url=https://w3c.github.io/payment-request/',
-  SUCCESS3 = '?type=respec&url=https://w3c.github.io/resource-hints/';
+  BASE_URL = `http://localhost:3000/?${process.env.AUTHORIZATION}`,
+  NO_URL = '&type=foo&URL=notice-that-its-in-uppercase',
+  NO_TYPE = '&url=foo&TYPE=notice-that-its-in-uppercase',
+  BAD_GENERATOR = '&type=fluxor&url=http://example.com/',
+  BAD_SHORTNAME = '&type=RESPEC&url=http://example.com/%3FshortName%3Ddiplodocus',
+  NO_RESPEC = '&type=RESPEC&url=http://example.com/',
+  SUCCESS1 = '&type=respec&url=https://w3c.github.io/manifest/',
+  SUCCESS2 = '&type=respec&url=https://w3c.github.io/payment-request/',
+  SUCCESS3 = '&type=respec&url=https://w3c.github.io/resource-hints/';
 
 const FAILS_WITH = (done, expectedMessage = '{"error":"Both \'type\' and \'url\' are required."}', expectedCode = 500) =>
   (error, response, body) => {

--- a/test/test.js
+++ b/test/test.js
@@ -1,0 +1,67 @@
+'use strict';
+
+const ASSERT = require('assert'),
+  REQUEST = require('request'),
+  SPEC_GEN = require('../server');
+
+const PORT = 3000,
+  BASE_URL = 'http://localhost:3000/',
+  NO_URL = '?type=foo&URL=notice-that-its-in-uppercase',
+  NO_TYPE = '?url=foo&TYPE=notice-that-its-in-uppercase',
+  BAD_GENERATOR = '?type=fluxor&url=http://example.com/',
+  BAD_SHORTNAME = '?type=RESPEC&url=http://example.com/%3FshortName%3Ddiplodocus',
+  NO_RESPEC = '?type=RESPEC&url=http://example.com/',
+  SUCCESS1 = '?type=respec&url=https://w3c.github.io/manifest/',
+  SUCCESS2 = '?type=respec&url=https://w3c.github.io/payment-request/',
+  SUCCESS3 = '?type=respec&url=https://w3c.github.io/resource-hints/';
+
+const FAILS_WITH = (done, expectedMessage = '{"error":"Both \'type\' and \'url\' are required."}', expectedCode = 500) =>
+  (error, response, body) => {
+    ASSERT.equal(error, null);
+    ASSERT.equal(response.statusCode, expectedCode);
+    if (expectedMessage instanceof RegExp)
+      ASSERT.ok(body.match(expectedMessage));
+    else
+      ASSERT.equal(body, expectedMessage);
+    done();
+  }
+;
+
+const SUCCEEDS = (done) =>
+  (error, response, body) => {
+    ASSERT.equal(error, null);
+    ASSERT.equal(response.statusCode, 200);
+    ASSERT.equal(response.statusMessage, 'OK');
+    done();
+  };
+;
+
+let server;
+
+describe('spec-generator', () => {
+
+  before(() => {
+    server = SPEC_GEN.start(PORT);
+  });
+
+  describe('fails when it should', () => {
+    it('without parameters', (done) => REQUEST.get(BASE_URL, FAILS_WITH(done)));
+    it('if there\'s no URL', (done) => REQUEST.get(BASE_URL + NO_URL, FAILS_WITH(done)));
+    it('if there\'s no type', (done) => REQUEST.get(BASE_URL + NO_TYPE, FAILS_WITH(done)));
+    it('if the generator is not valid', (done) => REQUEST.get(BASE_URL + BAD_GENERATOR, FAILS_WITH(done, '{"error":"Unknown generator: fluxor"}')));
+    it('if the shortname is not valid', (done) => REQUEST.get(BASE_URL + BAD_SHORTNAME, FAILS_WITH(done, '{"error":"Not Found"}', 404)));
+    it('if the URL does not point to a Respec document', (done) => REQUEST.get(BASE_URL + NO_RESPEC, FAILS_WITH(
+      done,
+      /That\ doesn't\ seem\ to\ be\ a\ ReSpec\ document\.\ Please\ check\ manually\:/
+    )));
+  });
+
+  describe('succeeds when it should', () => {
+    it('Web App Manifest ("appmanifest")', (done) => REQUEST.get(BASE_URL + SUCCESS1, SUCCEEDS(done)));
+    it('Payment Request API ("payment-request")', (done) => REQUEST.get(BASE_URL + SUCCESS2, SUCCEEDS(done)));
+    it('Resource Hints ("resource-hints")', (done) => REQUEST.get(BASE_URL + SUCCESS3, SUCCEEDS(done)));
+  });
+
+  after(() => server.close());
+
+});


### PR DESCRIPTION
* Add a simple test suite using Mocha, with 9 tests (6 should fail, 3 should pass), which relies on internet connectivity to fetch some documents
* Expose spec-generator as a Node.js module (simply because it was useful for testing, and it may come useful in the future anyway) in a very simple way
* README updated to reflect that new way to use the software
* Two bugfixes:
  * Fetch specs via HTTPS now (`https://www.w3.org/TR/...`)
  * If a certain shortname does not exist, the resulting 404 error page is now handled properly

Indentation fixed in `server.js`. That causes bogus changes in the diff; make sure to append `?w=1` to that URL to ignore those.

(The build in Travis is failing now just because it hits GH's API rate limit.)

@marcoscaceres :arrow_up: