### PR TITLE
increase timeout

### DIFF
--- a/generators/respec.js
+++ b/generators/respec.js
@@ -8,7 +8,7 @@ class SpecGeneratorError extends Error {
 }
 
 exports.generate = async function generate(url) {
-  const opts = { timeout: 20000, disableSandbox: true };
+  const opts = { timeout: 30000, disableSandbox: true };
   try {
     console.log("Generating", url);
     const result = await respecWriter(url, "/dev/null", {}, opts);


### PR DESCRIPTION
spec-generator is timing out on some large respec documents:
https://labs.w3.org/spec-generator/?type=respec&url=https://w3c.github.io/json-ld-syntax

That PR increases the timeout from 20s to 30s.