### PR TITLE
Add support to handle POST requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,9 @@ coverage
 # Compiled binary addons (http://nodejs.org/api/addons.html)
 build/Release
 
+# temporary uploaded files
+uploads
+
 # Dependency directory
 # Commenting this out is preferred by some people, see
 # https://www.npmjs.org/doc/misc/npm-faq.html#should-i-check-my-node_modules-folder-into-git-

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "license": "MIT",
   "dependencies": {
     "express": "4.17.1",
+    "express-fileupload": "1.1.6",
     "request": "2.88.0",
     "respec": "25.0.1",
     "whacko": "0.19.1"
@@ -13,8 +14,8 @@
     "mocha": "6.2.2"
   },
   "engines": {
-    "node": ">=5.10",
-    "npm": ">=3.3.6"
+    "node": "8 || 10 || 12",
+    "npm": ">=6"
   },
   "scripts": {
     "test": "mocha"

--- a/server.js
+++ b/server.js
@@ -112,7 +112,7 @@ app.post("/", async (req, res) => {
         } else {
             const file = req.files.file,
                   baseUrl = req.protocol + "://" + req.headers.host + '/',
-                  params = Object.keys(req.body).map(key => key + '=' + req.body[key]).join('&');
+                  params = req.body ? Object.keys(req.body).map(key => key + '=' + req.body[key]).join('&') : "";
                   src = baseUrl  + file.tempFilePath + ('?' + params || ""),
                   qs = {url: src, type: 'respec'};
             request.get({url: baseUrl, qs: qs}, (err, response, body) => {

--- a/server.js
+++ b/server.js
@@ -12,7 +12,7 @@ var express = require("express")
 ,   path = require('path')
 ,   request = require("request")
 ,   URL = require('url').URL
-,   fileUpload = require('express-fileupload');
+,   fileUpload = require('express-fileupload')
 ;
 
 app.use(fileUpload({

--- a/server.js
+++ b/server.js
@@ -9,9 +9,17 @@ var express = require("express")
         if (str.length >= 2) return str;
         return "0" + str;
     }
+,   path = require('path')
 ,   request = require("request")
 ,   URL = require('url').URL
+,   fileUpload = require('express-fileupload');
 ;
+
+app.use(fileUpload({
+    createParentPath: true,
+    useTempFiles: true,
+    tempFileDir: 'uploads/'
+}));
 
 // Listens to GET at the root, expects two required query string parameters:
 //  type:   the type of the generator (case-insensitive)
@@ -29,8 +37,8 @@ app.get("/", function (req, res) {
     var shortName = specURL.searchParams.get("shortName");
 
     let publishDate;
-    if (req.query.publishDate) {
-        publishDate = req.query.publishDate;
+    if (specURL.searchParams.get("publishDate")) {
+        publishDate = specURL.searchParams.get("publishDate");
     } else {
         const d = new Date();
         publishDate = [d.getFullYear(), num2(d.getMonth() + 1), num2(d.getDate())].join("-");
@@ -85,6 +93,40 @@ app.get("/", function (req, res) {
         } catch (err) {
             res.status(err.status).json({ error: err.message });
         }
+    }
+});
+
+app.use('/uploads', express.static('./uploads', {
+  setHeaders: (res, requestPath) => {
+      let noExtension = !Boolean(path.extname(requestPath));
+      if (noExtension) res.setHeader('Content-Type', 'text/html');
+    }}));
+
+app.post("/", async (req, res) => {
+    try {
+        if (!req.files) {
+            res.send({
+                status: 500,
+                message: 'No file uploaded'
+            });
+        } else {
+            const file = req.files.file,
+                  baseUrl = req.protocol + "://" + req.headers.host + '/',
+                  params = Object.keys(req.body).map(key => key + '=' + req.body[key]).join('&');
+                  src = baseUrl  + file.tempFilePath + ('?' + params || ""),
+                  qs = {url: src, type: 'respec'};
+            request.get({url: baseUrl, qs: qs}, (err, response, body) => {
+                if (err) {
+                    res.status(500).send(err);
+                } else {
+                    res.send(body);
+                    // delete temp file
+                    require("fs").promises.unlink(file.tempFilePath);
+                }
+            });
+        }
+    } catch (err) {
+        res.status(500).send(err);
     }
 });
 


### PR DESCRIPTION
Following a suggestion from @sideshowbarker , that PR adds support for POST requests so spec-generator doesn't have to rely on a document that is already staged somewhere.

Since [`respecDocWriter`](https://github.com/w3c/respec/blob/develop/tools/respecDocWriter.js) only takes a URL as a parameter, the idea is to download the file, expose it with express and delete it after it's been processed.

Users should then be able to submit their documents with POST requests. For instance
`curl <specgenerator_url> -F "file=@/tmp/index.html" -F "shortName=<shortname>" -F "publishDate=2020-01-31" -F specStatus="WD"`

/cc @plehegar 