### PR TITLE
add tar support when uploading files

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,9 +5,12 @@
   "dependencies": {
     "express": "4.17.1",
     "express-fileupload": "1.1.6",
+    "file-type": "14.6.0",
     "jsdom": "16.3.0",
+    "mkdirp": "1.0",
     "request": "2.88.2",
-    "respec": "25.13.0"
+    "respec": "25.13.0",
+    "tar-stream": "2.1.2"
   },
   "devDependencies": {
     "mocha": "8.0.1",


### PR DESCRIPTION
That PR adds support for tar files. Some documents can rely on multiple files to generate the final snapshot.

Fix https://github.com/w3c/spec-generator/issues/308

@michael-n-cooper I noticed that the spec you mentioned in the issue (https://github.com/w3c/wcag/blob/master/guidelines/index.html) relies on a few relatives files that aren't in the same repository. For this to be working, all the files should be in the tar file and the paths should be updated as well. Does that work for you?