### PR TITLE
get error, warning count as response headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ If the specific generator encounters a problem a similar error (mostly likely `5
 sort of JSON message is returned. Specific generator types can extend this behaviour. The `respec`
 generator only returns `500` errors.
 
+The HTTP response status code is `200` even when there are processing errors and warnings. Processing errors and warnings are signaled with the help of `x-errors-count` and `x-warnings-count` response headers respectively instead.
+
 ## Writing generators
 
 Generators are simple to write and new ones can easily be added. Simply add a new one under

--- a/generators/respec.js
+++ b/generators/respec.js
@@ -10,11 +10,11 @@ class SpecGeneratorError extends Error {
 exports.generate = async function generate(url) {
   try {
     console.log("Generating", url);
-    const { html } = await toHTML(url, {
+    const { html, errors, warnings } = await toHTML(url, {
       timeout: 30000,
       disableSandbox: true,
     });
-    return html;
+    return { html, errors: errors.length, warnings: warnings.length };
   } catch (err) {
     throw new SpecGeneratorError({ status: 500, message: err.message });
   }


### PR DESCRIPTION
See https://github.com/w3c/spec-generator/pull/353#issuecomment-713540236

Both GET and POST requests now return following headers with count of errors and warnings during processing:
```http
x-errors-count: <number>
x-warnings-count: <number>
```

@deniak Let me know if you prefer some other approach. We have access to error messages, but I'm not sure how we can show them (I don't think they belong to headers). So, error count maybe "good enough".