### PR TITLE
chore(.eslintrc.json): remove consistent-return

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -5,7 +5,7 @@
         "prettier/prettier": "error",
         "func-names": "off",
         "vars-on-top": "off",
-        "consistent-return": "off"        
+        "consistent-return": "off"
     },
     "overrides": [
         {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,8 +3,8 @@
     "plugins": ["prettier"],
     "rules": {
         "prettier/prettier": "error",
-        "consistent-return":"off",
         "func-names": "off",
+        "consistent-return": "off",
         "vars-on-top": "off"
     },
     "overrides": [

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,6 +3,7 @@
     "plugins": ["prettier"],
     "rules": {
         "prettier/prettier": "error",
+        "consistent-return":"off",
         "func-names": "off",
         "vars-on-top": "off"
     },

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,8 +4,7 @@
     "rules": {
         "prettier/prettier": "error",
         "func-names": "off",
-        "vars-on-top": "off",
-        "consistent-return":"warn"
+        "vars-on-top": "off"
     },
     "overrides": [
         {

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,8 +4,8 @@
     "rules": {
         "prettier/prettier": "error",
         "func-names": "off",
-        "consistent-return": "off",
-        "vars-on-top": "off"
+        "vars-on-top": "off",
+        "consistent-return": "off"        
     },
     "overrides": [
         {


### PR DESCRIPTION
Remove noisy rule... as our code show, there are valid cases for arrow functions that don't return anything.