### PR TITLE
disable GPU acceleration

### DIFF
--- a/generators/respec.js
+++ b/generators/respec.js
@@ -15,6 +15,7 @@ export async function generate(url) {
         const { html, errors, warnings } = await toHTML(url, {
             timeout: 30000,
             disableSandbox: true,
+            disableGPU: true,
         });
         return { html, errors: errors.length, warnings: warnings.length };
     } catch (err) {


### PR DESCRIPTION
To save some resources, we should disable the GPU acceleration with puppeteer.
This is pending a new respec release including https://github.com/w3c/respec/pull/4606