### PR TITLE
Recognize ./index.html in tar files

### DIFF
--- a/server.js
+++ b/server.js
@@ -52,7 +52,7 @@ async function extractTar(tarFile) {
         extract.on("entry", (header, stream, next) => {
             stream.on("data", async data => {
                 if (uploadedFileIsAllowed(header.name)) {
-                    if (!hasIndex && header.name === "index.html") {
+                    if (header.name === "index.html" || header.name === "./index.html") {
                         hasIndex = true;
                     }
                     const filePath = `${uploadPath}/${header.name}`;


### PR DESCRIPTION
This updates server logic to recognize either `index.html` or `./index.html` (and removes the superfluous negative check).

This allows archives created with commands along the lines of `tar -C subdirectory/ -cf spec.tar.gz .` to work.

Previously, archives needed to be created carefully, along the lines of `cd subdirectory/; tar -cf ../spec.tar.gz *; cd -` to prevent `./` from being prepended to all entry names.

After this update, archives with `./index.html` entries work equivalently to those with `index.html` entries.