### PR TITLE
Allow server to start when running with pm2

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -270,4 +270,5 @@ export const start = (port = parseInt(process.env.PORT || "", 10) || 8000) => {
     return app.listen(port);
 };
 
-if (process.argv[1] === fileURLToPath(import.meta.url) || process.env.pm_id) start();
+if (process.argv[1] === fileURLToPath(import.meta.url) || process.env.pm_id)
+    start();


### PR DESCRIPTION
In the context of pm2, the first argument will not match the script name. That PR checks the pm2 process id to see if we are running the application with pm2 and if that's the case, starts the server.