### PR TITLE
Honor type via either query param or body for POST requests

### DIFF
--- a/server.ts
+++ b/server.ts
@@ -228,9 +228,10 @@ app.post("/", async (req, res) => {
                 : // assume it's an HTML file
                   tempFilePath;
 
-        const generatorType = new URLSearchParams(req.body).get("type");
+        const generatorType =
+            new URLSearchParams(req.body).get("type") || "" + req.query.type;
         if (!generatorType) {
-            res.status(400).send("Missing type in POST body");
+            res.status(400).send("Missing type in POST body or query params");
             return;
         }
         if (!isGeneratorType(generatorType)) {


### PR DESCRIPTION
This fixes a regression present in 2.0. Some github workflows have historically relied on passing `type=respec` within query params, while also using POST and uploading a file. (For example, [WCAG 3's gh-pages workflow](https://github.com/w3c/wcag3/blob/20db06079619fc93e5a3c1e1236fa77397efbe3a/.github/workflows/gh-pages-deploy.yml#L40-L42), which failed because of this.)

This is not present in our test cases, which currently don't test the POST route. I'll need to investigate how to facilitate testing file uploads. I'm also investigating making the server code more resilient to this distinction in my future work, which may also open up more opportunities to test the POST route.

(It turns out my [changes to stop hard-coding `respec` which Denis had commented on](https://github.com/w3c/spec-generator/pull/702#discussion_r2418890321) did in fact hide a bug, but for a different reason unrelated to using the HTML form.)