### PR TITLE
ReSpec: Return more accurate error responses

### DIFF
--- a/generators/respec.ts
+++ b/generators/respec.ts
@@ -73,7 +73,10 @@ async function extractTar(tarFile: Buffer<ArrayBufferLike>) {
 
   const { promise, resolve, reject } = Promise.withResolvers<string>();
   extract.on("finish", () => {
-    if (!hasIndex) reject("No index.html file");
+    if (!hasIndex)
+      reject(
+        new SpecGeneratorError({ message: "No index.html file", status: 400 }),
+      );
     else resolve(uploadPath);
   });
 
@@ -164,28 +167,33 @@ const trimMessages = (messages: ToHTMLMessage[]) =>
 /** Generates response for validated respec requests. */
 export async function generateRespec(result: ValidateParamsResult) {
   const { params, res } = result;
-  const { specUrl, extraPath } = await resolveUrlOrFile(result);
 
   try {
-    const { html, errors, warnings } = await invokeRespec(specUrl, params);
-    res.setHeader("x-errors-count", errors.length);
-    res.setHeader("x-warnings-count", warnings.length);
+    const { specUrl, extraPath } = await resolveUrlOrFile(result);
 
-    // Mimic respec CLI's haltonerror / haltonwarning behavior
-    const dieOn = params.get("die-on");
-    const failed =
-      (errors.length && dieOn && dieOn !== "nothing") ||
-      ((errors.length || warnings.length) && dieOn === "everything");
-    if (!failed && params.get("output") !== "messages") {
-      res.send(html);
-    } else {
-      res
-        .status(failed ? 422 : 200)
-        .json(trimMessages([...errors, ...warnings]));
+    try {
+      const { html, errors, warnings } = await invokeRespec(specUrl, params);
+      res.setHeader("x-errors-count", errors.length);
+      res.setHeader("x-warnings-count", warnings.length);
+
+      // Mimic respec CLI's haltonerror / haltonwarning behavior
+      const dieOn = params.get("die-on");
+      const failed =
+        (errors.length && dieOn && dieOn !== "nothing") ||
+        ((errors.length || warnings.length) && dieOn === "everything");
+      if (!failed && params.get("output") !== "messages") {
+        res.send(html);
+      } else {
+        res
+          .status(failed ? 422 : 200)
+          .json(trimMessages([...errors, ...warnings]));
+      }
+    } catch (err) {
+      res.status(err.status || 500).json({ error: err.message });
+    } finally {
+      if (extraPath) await rm(extraPath, { recursive: true }).catch(() => {});
     }
   } catch (err) {
-    res.status(err.status).json({ error: err.message });
-  } finally {
-    if (extraPath) await rm(extraPath, { recursive: true }).catch(() => {});
+    res.status(err.status || 500).json({ error: err.message });
   }
 }

--- a/test/respec.test.ts
+++ b/test/respec.test.ts
@@ -11,6 +11,7 @@ import {
 const URL_NO_RESPEC = "https://w3c.github.io/wcag/";
 const URL_SUCCESS = `https://w3c.github.io/spec-generator/respec.html`;
 const URL_SUCCESS_RAW = `https://raw.githubusercontent.com/w3c/spec-generator/refs/heads/gh-pages/respec.html`;
+const URL_404_RAW = `https://raw.githubusercontent.com/w3c/spec-generator/refs/heads/gh-pages/404.html`;
 const URL_ERROR = `https://w3c.github.io/spec-generator/respec-with-error.html`;
 const URL_WARNING = `https://w3c.github.io/spec-generator/respec-with-warning.html`;
 
@@ -45,6 +46,14 @@ describe("ReSpec", () => {
           500,
         ),
         failOnRejection,
+      ));
+
+    it("if the URL points to raw.githubusercontent but responds with 4xx", () =>
+      get({ type: "respec", url: URL_404_RAW }).then(
+        createErrorStatusTestCallback(
+          /{"error":"404 status received from raw.githubusercontent.com/,
+          400,
+        ),
       ));
   });
 


### PR DESCRIPTION
This updates 2 edge-case code paths for ReSpec processing to output a more appropriate JSON error response:

- When fetching from `raw.githubusercontent.com` returns a 4xx/5xx response (previously this wasn't being checked, which would lead to a confusing filesystem-related error)
- When a tar file is uploaded with no index.html (updated to respond with HTTP 400)