### PR TITLE
enable sandboxing when running puppeteer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,12 @@ jobs:
       - name: Install bikeshed
         run: pipx install bikeshed && bikeshed update
       - run: npm install
+      - name: Debug Puppeteer install state
+        run: |
+          npm ls puppeteer puppeteer-core || true
+          echo "PUPPETEER_SKIP_DOWNLOAD=$PUPPETEER_SKIP_DOWNLOAD"
+          echo "HOME=$HOME"
+          ls -R ~/.cache/puppeteer || true
       # See https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
       - name: Disable AppArmor
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,6 @@ name: spec-generator tests
 on: [push, pull_request, workflow_dispatch]
 
 env:
-  PUPPETEER_DANGEROUS_NO_SANDBOX: 1
   PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
   PUPPETEER_SKIP_DOWNLOAD: 1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,11 @@ name: spec-generator tests
 
 on: [push, pull_request, workflow_dispatch]
 
+env:
+  PUPPETEER_DANGEROUS_NO_SANDBOX: 1
+  PUPPETEER_EXECUTABLE_PATH: /usr/bin/google-chrome
+  PUPPETEER_SKIP_DOWNLOAD: 1
+
 jobs:
   test:
     runs-on: ubuntu-latest
@@ -17,17 +22,5 @@ jobs:
       - name: Install bikeshed
         run: pipx install bikeshed && bikeshed update
       - run: npm install
-      - name: Clean puppeteer cache
-        run: rm -rf ~/.cache/puppeteer
-      - run: npx puppeteer browsers install chrome
-      - name: Debug Puppeteer install state
-        run: |
-          npm ls puppeteer puppeteer-core || true
-          echo "PUPPETEER_SKIP_DOWNLOAD=$PUPPETEER_SKIP_DOWNLOAD"
-          echo "HOME=$HOME"
-          ls -R ~/.cache/puppeteer || true
-      # See https://chromium.googlesource.com/chromium/src/+/main/docs/security/apparmor-userns-restrictions.md
-      - name: Disable AppArmor
-        run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns
       - run: npx respec2html -e --timeout 30 --src "https://w3c.github.io/spec-generator/respec.html"
       - run: npm test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,8 @@ jobs:
       - name: Install bikeshed
         run: pipx install bikeshed && bikeshed update
       - run: npm install
+      - name: Clean puppeteer cache
+        run: rm -rf ~/.cache/puppeteer
       - run: npx puppeteer browsers install chrome
       - name: Debug Puppeteer install state
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,6 +17,7 @@ jobs:
       - name: Install bikeshed
         run: pipx install bikeshed && bikeshed update
       - run: npm install
+      - run: npx puppeteer browsers install chrome
       - name: Debug Puppeteer install state
         run: |
           npm ls puppeteer puppeteer-core || true

--- a/generators/respec.ts
+++ b/generators/respec.ts
@@ -33,7 +33,6 @@ async function invokeRespec(url: URL, params: URLSearchParams) {
 
     const { html, errors, warnings } = await toHTML(url.href, {
       timeout: 30000,
-      disableSandbox: true,
       disableGPU: true,
     });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "express-fileupload": "^1.5.0",
         "file-type": "^22.0.1",
         "filenamify": "^7.0.1",
-        "respec": "37.0.0",
+        "respec": "37.1.0",
         "tar-stream": "^3.2.0",
         "tsx": "^4.21.0",
         "typescript": "^6.0.3"
@@ -33,12 +33,12 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -47,9 +47,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -482,9 +482,9 @@
       }
     },
     "node_modules/@puppeteer/browsers": {
-      "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.0.tgz",
-      "integrity": "sha512-46BZJYJjc/WwmKjsvDFykHtXrtomsCIrwYQPOP7VfMJoZY2bsDF9oROBABR3paDjDcmkUye1Pb1BqdcdiipaWA==",
+      "version": "2.13.2",
+      "resolved": "https://registry.npmjs.org/@puppeteer/browsers/-/browsers-2.13.2.tgz",
+      "integrity": "sha512-5EUZSUIc37H6aIXyWO0Z4y8NlF8NnjgmqeQgOGiswAU7pY0HOo16ho4+alIWmSfdZnjqBRawMsP3I5YqLSn6kw==",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.4.3",
@@ -1196,9 +1196,9 @@
       }
     },
     "node_modules/devtools-protocol": {
-      "version": "0.0.1595872",
-      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1595872.tgz",
-      "integrity": "sha512-kRfgp8vWVjBu/fbYCiVFiOqsCk3CrMKEo3WbgGT2NXK2dG7vawWPBljixajVgGK9II8rDO9G0oD0zLt3I1daRg==",
+      "version": "0.0.1608973",
+      "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1608973.tgz",
+      "integrity": "sha512-Tpm17fxYzt+J7VrGdc1k8YdRqS3YV7se/M6KeemEqvUbq/n7At1rWVuXMxQgpWkdwSdIEKYbU//Bve+Shm4YNQ==",
       "license": "BSD-3-Clause"
     },
     "node_modules/dom-serializer": {
@@ -2412,18 +2412,18 @@
       }
     },
     "node_modules/puppeteer": {
-      "version": "24.42.0",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.42.0.tgz",
-      "integrity": "sha512-94MoPfFp2eY3eYIMdINkez4IOP5TMHntlZbVx06fHlQTtiQiYgaY0L2Zzfod8PVUkPqP7m3Qlre2v8YS8cudPA==",
+      "version": "24.43.1",
+      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.43.1.tgz",
+      "integrity": "sha512-/FSOViCrqRdb1HDocpsM9Z1giA71gTQPUt3SpHGVRALKAy/rJr1fLFYZW9F23qPxqVxTHQnbh/5B5opJST3kAw==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.13.0",
+        "@puppeteer/browsers": "2.13.2",
         "chromium-bidi": "14.0.0",
         "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1595872",
-        "puppeteer-core": "24.42.0",
-        "typed-query-selector": "^2.12.1"
+        "devtools-protocol": "0.0.1608973",
+        "puppeteer-core": "24.43.1",
+        "typed-query-selector": "^2.12.2"
       },
       "bin": {
         "puppeteer": "lib/cjs/puppeteer/node/cli.js"
@@ -2433,18 +2433,18 @@
       }
     },
     "node_modules/puppeteer-core": {
-      "version": "24.42.0",
-      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.42.0.tgz",
-      "integrity": "sha512-T4zXokk/izH01fYPhyyev1A4piWiOKrYq7CUFpdoYQxmOnXoV6YjUabmfIjCYkNspSoAXIxRid3Tw+Vg0fthYg==",
+      "version": "24.43.1",
+      "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.43.1.tgz",
+      "integrity": "sha512-T5ScUMAsmhdNbgDR41AGESYeS6V9MSgetkSnVhhW+gXvzC42VesKCn5ld87gAZDJ6vLHL9GkRvY9WtQWSnwFbw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@puppeteer/browsers": "2.13.0",
+        "@puppeteer/browsers": "2.13.2",
         "chromium-bidi": "14.0.0",
         "debug": "^4.4.3",
-        "devtools-protocol": "0.0.1595872",
-        "typed-query-selector": "^2.12.1",
+        "devtools-protocol": "0.0.1608973",
+        "typed-query-selector": "^2.12.2",
         "webdriver-bidi-protocol": "0.4.1",
-        "ws": "^8.19.0"
+        "ws": "^8.20.0"
       },
       "engines": {
         "node": ">=18"
@@ -2533,15 +2533,15 @@
       }
     },
     "node_modules/respec": {
-      "version": "37.0.0",
-      "resolved": "https://registry.npmjs.org/respec/-/respec-37.0.0.tgz",
-      "integrity": "sha512-/noXsrojHJ8Z1x+utgFWWTdDaSkkFIZ6AaOXxG2cnJmg4Mu0iJZ4C9uhnLKN+SXLwu3FmmK/h0283df2Bir4fA==",
+      "version": "37.1.0",
+      "resolved": "https://registry.npmjs.org/respec/-/respec-37.1.0.tgz",
+      "integrity": "sha512-CyqHXWXZjYB2vTIV0flHJUYO5+nsY2DG6HYzVMWVP7XZqAJblX1NVI97PbcX2P12dkedLKklJhT5dyPNtUCqFg==",
       "license": "W3C",
       "dependencies": {
         "colors": "1.4.0",
         "finalhandler": "^2.1.1",
-        "marked": "^18.0.2",
-        "puppeteer": "^24.42.0",
+        "marked": "^18.0.3",
+        "puppeteer": "^24.43.1",
         "sade": "^1.8.1",
         "serve-static": "^2.2.1"
       },
@@ -2612,9 +2612,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.1.tgz",
+      "integrity": "sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==",
       "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
@@ -2753,9 +2753,9 @@
       }
     },
     "node_modules/socks": {
-      "version": "2.8.8",
-      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.8.tgz",
-      "integrity": "sha512-NlGELfPrgX2f1TAAcz0WawlLn+0r3FyhhCRpFFK2CemXenPYvzMWWZINv3eDNo9ucdwme7oCHRY0Jnbs4aIkog==",
+      "version": "2.8.9",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.8.9.tgz",
+      "integrity": "sha512-LJhUYUvItdQ0LkJTmPeaEObWXAqFyfmP85x0tch/ez9cahmhlBBLbIqDFnvBnUJGagb0JbIQrkBs1wJ+yRYpEw==",
       "license": "MIT",
       "dependencies": {
         "ip-address": "^10.1.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "express-fileupload": "^1.5.0",
     "file-type": "^22.0.1",
     "filenamify": "^7.0.1",
-    "respec": "37.0.0",
+    "respec": "37.1.0",
     "tar-stream": "^3.2.0",
     "tsx": "^4.21.0",
     "typescript": "^6.0.3"


### PR DESCRIPTION
We initially disabled sandboxing to mitigate the unprivileged user namespace restrictions but as far as I can tell, we can now re-enable sandboxing.