### PR TITLE
fix(security): mitigate SSRF on the url parameter

### DIFF
--- a/generators/bikeshed.ts
+++ b/generators/bikeshed.ts
@@ -7,6 +7,7 @@ import { promisify } from "util";
 import filenamify from "filenamify";
 
 import type { ValidateParamsResult } from "../server.js";
+import { safeFetch } from "../ssrf.js";
 import { SpecGeneratorError } from "./common.js";
 
 interface BikeshedMessage {
@@ -178,7 +179,7 @@ const generateIssuesList = async (input: string) => {
   if (!/^https?:\/\//.test(input)) return invokeBikeshed(input, "issues-list");
 
   const filename = generateFilename(input);
-  const response = await fetch(input);
+  const response = await safeFetch(input);
   if (response.status >= 400) {
     throw new SpecGeneratorError(
       `URL ${input} responded with ${response.status} status`,

--- a/generators/respec.ts
+++ b/generators/respec.ts
@@ -9,6 +9,7 @@ import { toHTML } from "respec";
 import tar from "tar-stream";
 
 import type { ValidateParamsResult } from "../server.js";
+import { safeFetch, checkHostname } from "../ssrf.js";
 import { getShortIsoDate, mergeParams } from "../util.js";
 import { SpecGeneratorError } from "./common.js";
 
@@ -87,7 +88,7 @@ const rawGithubRegex = /https:\/\/raw.githubusercontent.com\/.+?\/.+?\/.+?\//;
 
 async function crawlRaw(url: string) {
   const uploadPath = await mkdtemp("uploads/");
-  const response = await fetch(url);
+  const response = await safeFetch(url);
   if (response.status >= 400) {
     throw new SpecGeneratorError({
       message: `${response.status} status received from raw.githubusercontent.com request (check URL?)`,
@@ -116,7 +117,7 @@ async function crawlRaw(url: string) {
     await mkdir(`${uploadPath}/${dirname(name)}`, {
       recursive: true,
     });
-    const response = await fetch(l);
+    const response = await safeFetch(l);
     await writeFile(`${uploadPath}/${name}`, await response.bytes());
   }
 
@@ -149,6 +150,7 @@ async function resolveUrlOrFile(result: ValidateParamsResult) {
         extraPath,
       };
     } else {
+      await checkHostname(new URL(url).hostname);
       return { specUrl: new URL(url) };
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "express-fileupload": "^1.5.0",
         "file-type": "^22.0.1",
         "filenamify": "^7.0.2",
+        "ipaddr.js": "^2.4.0",
         "respec": "37.1.0",
         "tar-stream": "^3.2.0",
         "tsx": "^4.22.4",
@@ -1981,12 +1982,12 @@
       }
     },
     "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10"
       }
     },
     "node_modules/is-arrayish": {
@@ -2370,6 +2371,15 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "express-fileupload": "^1.5.0",
     "file-type": "^22.0.1",
     "filenamify": "^7.0.2",
+    "ipaddr.js": "^2.4.0",
     "respec": "37.1.0",
     "tar-stream": "^3.2.0",
     "tsx": "^4.22.4",

--- a/ssrf.ts
+++ b/ssrf.ts
@@ -1,0 +1,73 @@
+import dns from "dns/promises";
+
+import ipaddr from "ipaddr.js";
+
+import { SpecGeneratorError } from "./generators/common.js";
+
+const ALLOWED_RANGES = new Set(["unicast"]);
+
+function isBlockedIP(ip: string): boolean {
+  try {
+    let addr = ipaddr.parse(ip);
+    // Unwrap IPv4-mapped IPv6 (::ffff:x.x.x.x) so range() reflects the IPv4 range
+    if (addr.kind() === "ipv6" && (addr as ipaddr.IPv6).isIPv4MappedAddress()) {
+      addr = (addr as ipaddr.IPv6).toIPv4Address();
+    }
+    return !ALLOWED_RANGES.has(addr.range());
+  } catch {
+    return true;
+  }
+}
+
+export async function checkHostname(hostname: string): Promise<void> {
+  // If the hostname is already an IP literal, check it directly
+  if (ipaddr.isValid(hostname)) {
+    if (isBlockedIP(hostname)) {
+      throw new SpecGeneratorError({
+        message: `Blocked IP address: ${hostname}`,
+        status: 400,
+      });
+    }
+    return;
+  }
+
+  const { address } = await dns.lookup(hostname);
+  if (isBlockedIP(address)) {
+    throw new SpecGeneratorError({
+      message: `URL resolves to a blocked IP address`,
+      status: 400,
+    });
+  }
+}
+
+/**
+ * Drop-in fetch() replacement that guards against SSRF.
+ * Resolves DNS before connecting and re-validates after every redirect.
+ */
+export async function safeFetch(
+  url: string | URL,
+  init?: RequestInit,
+  maxRedirects = 5,
+): Promise<Response> {
+  let current = typeof url === "string" ? url : url.href;
+
+  for (let i = 0; i <= maxRedirects; i++) {
+    const parsed = new URL(current);
+    await checkHostname(parsed.hostname);
+
+    const response = await fetch(current, { ...init, redirect: "manual" });
+
+    // Not a redirect — return as-is
+    if (response.status < 300 || response.status >= 400) {
+      return response;
+    }
+
+    const location = response.headers.get("location");
+    if (!location) return response;
+
+    // Resolve relative Location headers
+    current = new URL(location, current).href;
+  }
+
+  throw new SpecGeneratorError({ message: "Too many redirects", status: 400 });
+}

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -59,4 +59,5 @@ describe("spec-generator", async () => {
   // within the same top-level suite and server instance
   await import("./bikeshed.test.js");
   await import("./respec.test.js");
+  await import("./ssrf.test.js");
 });

--- a/test/ssrf.test.ts
+++ b/test/ssrf.test.ts
@@ -1,0 +1,38 @@
+import assert from "assert";
+import { describe, it } from "node:test";
+
+// @ts-ignore — internal exports for testing
+import { checkHostname } from "../ssrf.js";
+import { SpecGeneratorError } from "../generators/common.js";
+
+async function assertBlocked(hostname: string) {
+  await assert.rejects(
+    () => checkHostname(hostname),
+    (err) => err instanceof SpecGeneratorError && err.status === 400,
+    `Expected ${hostname} to be blocked`,
+  );
+}
+
+describe("SSRF guard – checkHostname()", () => {
+  it("blocks loopback IPv4 literal", () => assertBlocked("127.0.0.1"));
+  it("blocks loopback IPv4 range", () => assertBlocked("127.0.0.2"));
+  it("blocks private 10.x.x.x", () => assertBlocked("10.0.0.1"));
+  it("blocks private 172.16.x.x", () => assertBlocked("172.16.0.1"));
+  it("blocks private 192.168.x.x", () => assertBlocked("192.168.1.1"));
+  it("blocks link-local / cloud metadata", () =>
+    assertBlocked("169.254.169.254"));
+  it("blocks 0.0.0.0", () => assertBlocked("0.0.0.0"));
+  it("blocks IPv6 loopback literal", () => assertBlocked("::1"));
+  it("blocks IPv6 link-local", () => assertBlocked("fe80::1"));
+  it("blocks IPv4-mapped IPv6 private", () =>
+    assertBlocked("::ffff:192.168.1.1"));
+  it("blocks IPv4-mapped IPv6 loopback", () =>
+    assertBlocked("::ffff:127.0.0.1"));
+  it("allows public IP", async () => {
+    // 1.1.1.1 is Cloudflare DNS — always public
+    await assert.doesNotReject(() => checkHostname("1.1.1.1"));
+  });
+  it("allows example.com (resolves to public IP)", async () => {
+    await assert.doesNotReject(() => checkHostname("example.com"));
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `ssrf.ts` with a `safeFetch()` wrapper and `checkHostname()` helper that guard against Server-Side Request Forgery on the `url` parameter
- Uses `ipaddr.js` (already a transitive dependency) to classify resolved IP addresses and block everything outside the public unicast range (loopback, private RFC-1918, link-local, cloud metadata `169.254.169.254`, multicast, unspecified)
- `safeFetch()` uses `redirect: "manual"` to intercept every redirect and re-validates the destination hostname before following it, capped at 5 hops
- Replaces bare `fetch()` calls in `generators/respec.ts` (`crawlRaw`) and `generators/bikeshed.ts` (`generateIssuesList`)
- Adds a `checkHostname()` guard in `resolveUrlOrFile()` before the URL is handed to ReSpec's `toHTML()`, which runs in a headless browser and cannot be intercepted at the fetch layer
- 13 unit tests covering all blocked ranges (IPv4, IPv6, IPv4-mapped IPv6) and the public allow-list

## What a reviewer should know

The fix follows the guidance from the security report: resolve DNS and block private/loopback/link-local/multicast/cloud-metadata ranges, and re-validate after every redirect. `ipaddr.js` handles the range classification so there is no hand-rolled CIDR arithmetic.

The `toHTML()` call in ReSpec cannot have its internal fetches intercepted (it spawns a headless browser), so the mitigation there is the upstream `checkHostname()` check — the URL is validated before being passed in.

## Test plan

- [ ] `npm test` passes (unit tests run via `tsx test/index.test.ts`)
- [ ] `curl "http://localhost:3000/?type=respec&url=http://169.254.169.254/"` → 400
- [ ] `curl "http://localhost:3000/?type=respec&url=http://127.0.0.1/"` → 400
- [ ] `curl "http://localhost:3000/?type=respec&url=http://192.168.1.1/"` → 400
- [ ] A valid public spec URL still generates correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)