### PR TITLE
Prevent url requests for internal addresses

### DIFF
--- a/generators/bikeshed.ts
+++ b/generators/bikeshed.ts
@@ -7,6 +7,7 @@ import { promisify } from "util";
 import filenamify from "filenamify";
 
 import type { ValidateParamsResult } from "../server.js";
+import { httpsProtocolPattern } from "../util.js";
 import { SpecGeneratorError } from "./common.js";
 
 interface BikeshedMessage {
@@ -175,7 +176,8 @@ const generateSpec = async (input: string, params: URLSearchParams) => {
 
 /** Runs `bikeshed issues-list`, fetching from remote server if a URL is specified. */
 const generateIssuesList = async (input: string) => {
-  if (!/^https?:\/\//.test(input)) return invokeBikeshed(input, "issues-list");
+  if (!httpsProtocolPattern.test(input))
+    return invokeBikeshed(input, "issues-list");
 
   const filename = generateFilename(input);
   const response = await fetch(input);

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "express-fileupload": "^1.5.0",
         "file-type": "^22.0.1",
         "filenamify": "^7.0.2",
+        "ipaddr.js": "^2.4.0",
         "respec": "37.1.0",
         "tar-stream": "^3.2.0",
         "tsx": "^4.22.4",
@@ -1981,12 +1982,12 @@
       }
     },
     "node_modules/ipaddr.js": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
-      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-2.4.0.tgz",
+      "integrity": "sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==",
       "license": "MIT",
       "engines": {
-        "node": ">= 0.10"
+        "node": ">= 10"
       }
     },
     "node_modules/is-arrayish": {
@@ -2370,6 +2371,15 @@
         "forwarded": "0.2.0",
         "ipaddr.js": "1.9.1"
       },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
+    "node_modules/proxy-addr/node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
       "engines": {
         "node": ">= 0.10"
       }

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "express-fileupload": "^1.5.0",
     "file-type": "^22.0.1",
     "filenamify": "^7.0.2",
+    "ipaddr.js": "^2.4.0",
     "respec": "37.1.0",
     "tar-stream": "^3.2.0",
     "tsx": "^4.22.4",

--- a/server.ts
+++ b/server.ts
@@ -8,7 +8,7 @@ import fileUpload from "express-fileupload";
 
 import { generateBikeshed } from "./generators/bikeshed.js";
 import { generateRespec } from "./generators/respec.js";
-import { mergeRequestParams } from "./util.js";
+import { isUnicastHttpUrl, mergeRequestParams } from "./util.js";
 
 const app = express();
 
@@ -45,7 +45,7 @@ const FORM_HTML = await readFile("index.html", "utf-8");
  * In other cases, returns an object with information derived from the request,
  * and leaves the response to the consuming function.
  */
-function validateParams(req: Request, res: Response) {
+async function validateParams(req: Request, res: Response) {
   const params = mergeRequestParams(req);
   const type = params.get("type");
   const url = params.get("url");
@@ -78,10 +78,17 @@ function validateParams(req: Request, res: Response) {
     return null;
   }
 
+  if (url && !(await isUnicastHttpUrl(url))) {
+    res.status(400).json({
+      error: "Invalid url",
+    });
+    return null;
+  }
+
   return { file, params, req, res, type, url };
 }
 export type ValidateParamsResult = NonNullable<
-  ReturnType<typeof validateParams>
+  Awaited<ReturnType<typeof validateParams>>
 >;
 
 const handlers = {
@@ -94,13 +101,13 @@ const isGeneratorType = (type: string): type is GeneratorType =>
   handlers.hasOwnProperty(type);
 
 app.get("/", async (req, res) => {
-  const result = validateParams(req, res);
+  const result = await validateParams(req, res);
   if (!result) return;
   await handlers[result.type](result);
 });
 
 app.post("/", async (req, res) => {
-  const result = validateParams(req, res);
+  const result = await validateParams(req, res);
   if (!result) return;
   await handlers[result.type](result);
   if (result.file) await unlink(result.file.tempFilePath).catch(() => {});

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -46,6 +46,33 @@ describe("spec-generator", async () => {
         ));
 
       describe("invalid URLs", () => {
+        const originalFetch = globalThis.fetch;
+
+        before(() => {
+          globalThis.fetch = async (input, init) => {
+            const urlStr = "" + input;
+            if (urlStr.includes("//w3.org/malicious-example/"))
+              return new Response(null, {
+                headers: { location: "http://192.168.1.2/" },
+                status: 301,
+              });
+            else if (urlStr.includes("//192.168.1.2"))
+              return new Response(null, { status: 200 });
+            else if (urlStr.includes("//w3.org/broken-example/"))
+              return new Response(null, {
+                headers: { location: "https://w3.org/broken-example/" },
+                status: 302,
+              });
+
+            // Pass through to allow actual server API calls to proceed as usual
+            return originalFetch(input, init);
+          };
+        });
+
+        after(() => {
+          globalThis.fetch = originalFetch;
+        });
+
         const urls = [
           // incomplete URL
           "//w3.org",
@@ -65,6 +92,9 @@ describe("spec-generator", async () => {
           "https://[::ffff:a9fe:102]", // IPv4-mapped IPv6 address
           // uniqueLocal
           "https://[fd00::1]",
+          // External URLs (not real, but need to use a real domain to avoid DNS lookup failures)
+          "https://w3.org/malicious-example/", // Redirects to internal IP via header
+          "https://w3.org/broken-example/", // Redirects infinitely
         ];
 
         const types = ["bikeshed-spec", "bikeshed-issues-list", "respec"];

--- a/test/index.test.ts
+++ b/test/index.test.ts
@@ -10,7 +10,7 @@ import {
   testFetchHelpers,
 } from "./test-util.js";
 
-const { get, post } = testFetchHelpers;
+const { get, post, testAll } = testFetchHelpers;
 
 describe("spec-generator", async () => {
   let testServer: Server;
@@ -44,6 +44,42 @@ describe("spec-generator", async () => {
           createErrorStatusTestCallback(/^{"error":"Missing type"}$/),
           failOnRejection,
         ));
+
+      describe("invalid URLs", () => {
+        const urls = [
+          // incomplete URL
+          "//w3.org",
+          "/publications/",
+          // wrong protocol
+          "ftp://example.com",
+          // localhost (loopback)
+          "http://127.0.0.1",
+          "http://[::1]",
+          "http://localhost",
+          // private
+          "https://192.168.1.2",
+          "https://10.100.11.2",
+          // linkLocal
+          "https://169.254.1.2",
+          "https://[fe80::1]",
+          "https://[::ffff:a9fe:102]", // IPv4-mapped IPv6 address
+          // uniqueLocal
+          "https://[fd00::1]",
+        ];
+
+        const types = ["bikeshed-spec", "bikeshed-issues-list", "respec"];
+
+        for (const url of urls) {
+          for (const type of types) {
+            testAll(`responds with 400 status for ${type} ${url}`, (request) =>
+              request({ type, url }).then(
+                createErrorStatusTestCallback(/^{"error":"Invalid url"}$/),
+                failOnRejection,
+              ),
+            );
+          }
+        }
+      });
     });
 
     describe("succeeds when it should", () => {

--- a/util.ts
+++ b/util.ts
@@ -1,4 +1,6 @@
+import { lookup } from "dns/promises";
 import type { Request } from "express";
+import ipaddr from "ipaddr.js";
 
 /**
  * Merges multiple URLSearchParams or FormData instances into the first one passed.
@@ -37,3 +39,53 @@ export function mergeRequestParams(req: Request) {
 
 /** Returns the current (local) date in YYYY-MM-DD format. */
 export const getShortIsoDate = () => new Date().toISOString().slice(0, 10);
+
+/** Pattern that matches HTTP(S) URLs */
+export const httpsProtocolPattern = /^https?:\/\//;
+
+/** Extracts or looks up IP address from a URL hostname. */
+async function resolveUrlToIpAddress({ hostname }: URL) {
+  if (ipaddr.isValid(hostname)) return hostname;
+  const maybeIPv6Hostname = hostname.replace(/^\[(.+)\]$/, "$1");
+  if (ipaddr.isValid(maybeIPv6Hostname)) return maybeIPv6Hostname;
+  return (await lookup(hostname)).address;
+}
+
+/** Parses an IP to check whether it is unicast. */
+function isUnicastIp(ip: string) {
+  const parsedIp = ipaddr.parse(ip);
+  const range =
+    parsedIp instanceof ipaddr.IPv6 && parsedIp.isIPv4MappedAddress()
+      ? parsedIp.toIPv4Address().range()
+      : parsedIp.range();
+  return range === "unicast";
+}
+
+/**
+ * Determines whether the provided URL points to a remote HTTP resource
+ * whose hostname corresponds to a unicast IP.
+ */
+export async function isUnicastHttpUrl(url: string) {
+  if (!httpsProtocolPattern.test(url)) return false;
+
+  const isUnicast = isUnicastIp(await resolveUrlToIpAddress(new URL(url)));
+  if (!isUnicast) return false;
+
+  // Check for redirects, to also validate the final URL
+  let currentUrl = url;
+  for (let allowedRedirects = 10; allowedRedirects > 0; allowedRedirects--) {
+    const { headers, status } = await fetch(currentUrl, {
+      method: "HEAD",
+      redirect: "manual",
+    });
+    const location = headers.get("location");
+    if (status >= 300 && status < 400 && location) currentUrl = location;
+    else break;
+
+    if (allowedRedirects === 1) {
+      console.error(`Redirect limit exceeded for ${url}`);
+      return false;
+    }
+  }
+  return isUnicastIp(await resolveUrlToIpAddress(new URL(currentUrl)));
+}

--- a/util.ts
+++ b/util.ts
@@ -48,11 +48,16 @@ async function resolveUrlToIpAddress({ hostname }: URL) {
   if (ipaddr.isValid(hostname)) return hostname;
   const maybeIPv6Hostname = hostname.replace(/^\[(.+)\]$/, "$1");
   if (ipaddr.isValid(maybeIPv6Hostname)) return maybeIPv6Hostname;
-  return (await lookup(hostname)).address;
+  try {
+    return (await lookup(hostname)).address;
+  } catch {
+    return null;
+  }
 }
 
 /** Parses an IP to check whether it is unicast. */
-function isUnicastIp(ip: string) {
+function isUnicastIp(ip: string | null) {
+  if (!ip) return false; // If ip is null, assume DNS lookup failure
   const parsedIp = ipaddr.parse(ip);
   const range =
     parsedIp instanceof ipaddr.IPv6 && parsedIp.isIPv4MappedAddress()


### PR DESCRIPTION
This responds with 400 status to any request whose URL points to an internal/local IP.

- Checks centrally in `validateParams` which covers all code paths (both GET and POST, all generators) before any generator is called
- Covers IPv4, IPv6, and domain lookups; also rejects non-HTTP(S) URLs
- If the initial URL is determined to be unicast, also performs HEAD request(s) to check for redirects to an internal host
- Centralizes one regular expression which had previously existed in `generators/bikeshed.ts`

I've added a collection of test cases which go through the full code path to verify the 400 response from the server and the proper handling of all types of URLs (including IPv6 which need to be enclosed in square brackets). The one thing that wouldn't be straightforward to automate testing of is the maximum redirects handling, which I have verified manually for the time being. (We might be able to introduce `nock` to this repo to automate testing that case, but perhaps I should do that separately later.)