### PR TITLE
ReSpec: Check for 4xx/5xx response codes when crawling links

### DIFF
--- a/generators/respec.ts
+++ b/generators/respec.ts
@@ -90,7 +90,7 @@ async function crawlRaw(url: string) {
   const response = await fetch(url);
   if (response.status >= 400) {
     throw new SpecGeneratorError({
-      message: `${response.status} status received from raw.githubusercontent.com request (check URL?)`,
+      message: `${response.status} status received from specified URL ${url} (check URL?)`,
       status: 400,
     });
   }
@@ -113,10 +113,16 @@ async function crawlRaw(url: string) {
 
   for (const l of links) {
     const name = l.replace(basePath, "");
+    const response = await fetch(l);
+    if (response.status >= 400) {
+      throw new SpecGeneratorError({
+        message: `${response.status} status received when following link to ${l} (check URL?)`,
+        status: 400,
+      });
+    }
     await mkdir(`${uploadPath}/${dirname(name)}`, {
       recursive: true,
     });
-    const response = await fetch(l);
     await writeFile(`${uploadPath}/${name}`, await response.bytes());
   }
 

--- a/test/respec.test.ts
+++ b/test/respec.test.ts
@@ -12,6 +12,7 @@ const URL_NO_RESPEC = "https://w3c.github.io/wcag/";
 const URL_SUCCESS = `https://w3c.github.io/spec-generator/respec.html`;
 const URL_SUCCESS_RAW = `https://raw.githubusercontent.com/w3c/spec-generator/refs/heads/gh-pages/respec.html`;
 const URL_404_RAW = `https://raw.githubusercontent.com/w3c/spec-generator/refs/heads/gh-pages/404.html`;
+const URL_404LINK_RAW = `https://raw.githubusercontent.com/w3c/vc-recognized-entities/49eaf7bd/index.html`;
 const URL_ERROR = `https://w3c.github.io/spec-generator/respec-with-error.html`;
 const URL_WARNING = `https://w3c.github.io/spec-generator/respec-with-warning.html`;
 
@@ -51,7 +52,15 @@ describe("ReSpec", () => {
     it("if the URL points to raw.githubusercontent but responds with 4xx", () =>
       get({ type: "respec", url: URL_404_RAW }).then(
         createErrorStatusTestCallback(
-          /{"error":"404 status received from raw.githubusercontent.com/,
+          /{"error":"404 status received from specified URL https:\/\/raw\.githubusercontent.com\//,
+          400,
+        ),
+      ));
+
+    it("if the URL points to raw.githubusercontent and a link in the document responds with 4xx", () =>
+      get({ type: "respec", url: URL_404LINK_RAW }).then(
+        createErrorStatusTestCallback(
+          /{"error":"404 status received when following link to https:\/\/raw\.githubusercontent\.com\//,
           400,
         ),
       ));


### PR DESCRIPTION
Resolves #803

This is effectively a repeat of #721, but for requests made for other URLs found in the document when crawling a raw.githubusercontent URL.

When Denis explained the background of the #803 report, I immediately suspected that a network request should have failed first and an error should have been reported about that, which would have been much clearer. This turned out to indeed be the case: while we've checked for 4xx/5xx status in the initial raw.githubusercontent request since 3.0.1, we still weren't checking for this in requests for any other links found in the document.

I have also updated the error text in the message added in #721 to mention the specific URL, though it is less critical in that case since it directly corresponds to the URL the user submitted.