### PR TITLE
Bikeshed: Reject instead of throwing on unexpected process exit

### DIFF
--- a/generators/bikeshed.ts
+++ b/generators/bikeshed.ts
@@ -128,8 +128,10 @@ async function invokeBikeshed(
           }
         }
       } catch {
-        throw new SpecGeneratorError(
-          "Bikeshed returned incomplete or unexpected output",
+        reject(
+          new SpecGeneratorError(
+            "Bikeshed returned incomplete or unexpected output",
+          ),
         );
       }
 


### PR DESCRIPTION
While looking at spec-generator service logs, I stumbled across the fact that it was crashing upon bikeshed terminating unexpectedly, due to accidentally using `throw` instead of `reject(...)` like the other code paths.

I'm not sure it's realistic to add an automated test for this, since it would require consistently causing bikeshed to crash, and the crash I reproduced is likely to be fixed in an upcoming patch release.